### PR TITLE
[Fix] 'Launching.State' initializer is inaccessible due to 'internal'…

### DIFF
--- a/Sources/LaunchingView/Launching.swift
+++ b/Sources/LaunchingView/Launching.swift
@@ -17,6 +17,10 @@ public struct Launching: ReducerProtocol {
     var forceUpdateAlert: AlertState<Action>?
     var isSuccess: Bool = false
     var optionalUpdateConfirm: ConfirmationDialogState<Action>?
+    
+    public init() {
+      
+    }
   }
   
   public enum Action: Equatable {


### PR DESCRIPTION
… protection level