### PR TITLE
[codex] DocC 배포 스크립트 단일화

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -22,19 +22,6 @@ jobs:
 
       - name: Build DocC
         run: |
-          swift build
-          swift package dump-symbol-graph --minimum-access-level public
-          rm -rf .build/docc-symbolgraphs docs LaunchingView.doccarchive
-          mkdir -p .build/docc-symbolgraphs
-          find .build -path '*/symbolgraph/LaunchingView*.symbols.json' \
-            ! -name 'LaunchingViewPackageTests.symbols.json' \
-            -exec cp {} .build/docc-symbolgraphs/ \;
-          xcrun docc convert Sources/LaunchingView/LaunchingView.docc \
-            --additional-symbol-graph-dir .build/docc-symbolgraphs \
-            --fallback-display-name LaunchingView \
-            --fallback-bundle-identifier com.swift-man.LaunchingView \
-            --fallback-bundle-version 0.9.0 \
-            --output-path LaunchingView.doccarchive
           ./GeneratingDocumentationSite
           touch ./docs/.nojekyll
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,25 +12,13 @@
 
 - Run `swift build` after code changes.
 - Run `swift test` for verification.
-- After a successful build, update DocC output before finalizing documentation changes:
+- After documentation changes, regenerate the local DocC static site before finalizing:
 
 ```bash
-swift package dump-symbol-graph --minimum-access-level public
-rm -rf .build/docc-symbolgraphs docs LaunchingView.doccarchive
-mkdir -p .build/docc-symbolgraphs
-find .build -path '*/symbolgraph/LaunchingView*.symbols.json' \
-  ! -name 'LaunchingViewPackageTests.symbols.json' \
-  -exec cp {} .build/docc-symbolgraphs/ \;
-xcrun docc convert Sources/LaunchingView/LaunchingView.docc \
-  --additional-symbol-graph-dir .build/docc-symbolgraphs \
-  --fallback-display-name LaunchingView \
-  --fallback-bundle-identifier com.swift-man.LaunchingView \
-  --fallback-bundle-version 0.9.0 \
-  --output-path LaunchingView.doccarchive
 ./GeneratingDocumentationSite
 ```
 
-- `./GeneratingDocumentationSite` transforms the temporary `LaunchingView.doccarchive/` into `docs/` and removes the archive afterward.
+- `./GeneratingDocumentationSite` builds the package, emits symbol graphs, converts `Sources/LaunchingView/LaunchingView.docc`, transforms the archive into static `docs/`, and removes temporary DocC artifacts afterward.
 - Do not commit generated DocC output. `docs/` and `LaunchingView.doccarchive/` are local/CI artifacts.
 - The `Deploy DocC` GitHub Actions workflow publishes generated documentation to `swift-man/docs` under `LaunchingView/`.
 - Configure `DOCS_DEPLOY_KEY` with a private deploy key in this repository, and add the matching public key with write access to `swift-man/docs`.

--- a/GeneratingDocumentationSite
+++ b/GeneratingDocumentationSite
@@ -1,11 +1,43 @@
 #!/bin/sh
-set -e
+set -eu
 
-DOCC_ARCHIVE_PATH="${DOCC_ARCHIVE_PATH:-./LaunchingView.doccarchive}"
+TARGET_NAME="${TARGET_NAME:-LaunchingView}"
+PACKAGE_BUILD_PATH="${PACKAGE_BUILD_PATH:-.build}"
+SYMBOL_GRAPH_PATH="${SYMBOL_GRAPH_PATH:-$PACKAGE_BUILD_PATH/docc-symbolgraphs}"
+DOCC_CATALOG_PATH="${DOCC_CATALOG_PATH:-Sources/$TARGET_NAME/$TARGET_NAME.docc}"
+DOCC_ARCHIVE_PATH="${DOCC_ARCHIVE_PATH:-./$TARGET_NAME.doccarchive}"
 DOCS_OUTPUT_PATH="${DOCS_OUTPUT_PATH:-./docs}"
-HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-docs/LaunchingView}"
+HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-docs/$TARGET_NAME}"
+BUNDLE_IDENTIFIER="${BUNDLE_IDENTIFIER:-com.swift-man.$TARGET_NAME}"
+BUNDLE_VERSION="${BUNDLE_VERSION:-0.9.0}"
+MINIMUM_ACCESS_LEVEL="${MINIMUM_ACCESS_LEVEL:-public}"
+DOCC="$(xcrun --find docc)"
 
-"$(xcrun --find docc)" process-archive \
+rm -rf "$SYMBOL_GRAPH_PATH" "$DOCS_OUTPUT_PATH" "$DOCC_ARCHIVE_PATH"
+mkdir -p "$SYMBOL_GRAPH_PATH"
+
+swift build
+if ! swift package dump-symbol-graph --minimum-access-level "$MINIMUM_ACCESS_LEVEL"; then
+  echo "warning: dump-symbol-graph exited non-zero; continuing if $TARGET_NAME symbols were emitted" >&2
+fi
+
+find "$PACKAGE_BUILD_PATH" -path "*/symbolgraph/$TARGET_NAME*.symbols.json" \
+  ! -name "${TARGET_NAME}PackageTests.symbols.json" \
+  -exec cp {} "$SYMBOL_GRAPH_PATH/" \;
+
+if [ -z "$(find "$SYMBOL_GRAPH_PATH" -name '*.symbols.json' -print -quit)" ]; then
+  echo "error: no symbol graphs found for $TARGET_NAME" >&2
+  exit 1
+fi
+
+"$DOCC" convert "$DOCC_CATALOG_PATH" \
+  --additional-symbol-graph-dir "$SYMBOL_GRAPH_PATH" \
+  --fallback-display-name "$TARGET_NAME" \
+  --fallback-bundle-identifier "$BUNDLE_IDENTIFIER" \
+  --fallback-bundle-version "$BUNDLE_VERSION" \
+  --output-path "$DOCC_ARCHIVE_PATH"
+
+"$DOCC" process-archive \
   transform-for-static-hosting "$DOCC_ARCHIVE_PATH" \
   --output-path "$DOCS_OUTPUT_PATH" \
   --hosting-base-path "$HOSTING_BASE_PATH"
@@ -13,4 +45,4 @@ HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-docs/LaunchingView}"
 find "$DOCS_OUTPUT_PATH" -type f -name '*.js' \
   -exec perl -0pi -e 's/[ \t]+$//mg' {} +
 
-rm -rf "$DOCC_ARCHIVE_PATH"
+rm -rf "$DOCC_ARCHIVE_PATH" "$SYMBOL_GRAPH_PATH"

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-doc.gorani.me


### PR DESCRIPTION
## 변경 사항
- `GeneratingDocumentationSite`가 DocC 배포 준비를 end-to-end로 수행하도록 확장했습니다.
  - `swift build`
  - `swift package dump-symbol-graph`
  - `LaunchingView` symbol graph 수집
  - `xcrun docc convert`
  - static hosting 변환
  - `docs/`, `.build/docc-symbolgraphs`, `LaunchingView.doccarchive` 임시 산출물 정리
- `.github/workflows/deploy-docc.yml`의 DocC build step을 `./GeneratingDocumentationSite` 호출 하나로 단순화했습니다.
- `dump-symbol-graph`가 CI에서 테스트 모듈 처리 후 non-zero로 끝나도, 실제 `LaunchingView` symbol graph가 생성되어 있으면 계속 진행하도록 했습니다.
- main에 남아 있던 `docs/CNAME`을 제거해 패키지 repo가 `docs/` 산출물을 보유하지 않는 원칙을 맞췄습니다.
- AGENTS.md의 DocC 생성 지침을 새 단일 스크립트 기준으로 갱신했습니다.

## 리뷰 코멘트 대응
PR #10의 리뷰에서 DocC 배포 파이프라인이 여러 명령으로 펼쳐져 있어 복잡하다는 개선 제안이 있었습니다. 공식 `Swift-DocC-Plugin`을 패키지 의존성으로 추가하면 명령은 짧아지지만, 이 라이브러리를 SPM으로 사용하는 소비자에게 문서 생성 도구 의존성까지 resolve될 수 있습니다.

그래서 이번 후속 PR에서는 plugin 의존성을 추가하지 않고, 기존 `xcrun docc` 방식을 유지하되 CI와 로컬 문서 생성 절차를 `GeneratingDocumentationSite` 하나로 합쳤습니다. 리뷰의 핵심인 유지보수성 문제를 해결하면서 패키지 의존성 표면은 늘리지 않는 방향입니다.

## 추가로 확인한 문제
PR #10을 main에 머지한 직후 `Deploy DocC` workflow가 실패했습니다. 로그상 `swift package dump-symbol-graph`가 `LaunchingView` symbol graph를 생성한 뒤 테스트 모듈 처리 과정에서 non-zero를 반환해 이후 단계가 중단되었습니다. 이 PR은 해당 상황에서도 target symbol graph 존재 여부를 기준으로 안전하게 진행하도록 고칩니다.

## 검증
- `sh -n GeneratingDocumentationSite`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-docc.yml"); puts "yaml ok"'`
- `./GeneratingDocumentationSite`
- `test -d docs && test ! -d LaunchingView.doccarchive && test ! -d .build/docc-symbolgraphs && git check-ignore -q docs/index.html`
- `swift test`
- `git diff --check`
