### PR TITLE
[codex] DocC custom domain 경로 보정

### DIFF
--- a/.reviewbot.yml
+++ b/.reviewbot.yml
@@ -8,6 +8,7 @@ review:
     - "Tuist/**/*.swift"
     - "**/Info.plist"
     - "README.md"
+    - "GeneratingDocumentationSite"
 
   exclude:
     # dependency / build output
@@ -57,6 +58,7 @@ review:
     - ".reviewbot.yml"
     - "AGENTS.md"
     - "README.md"
+    - "GeneratingDocumentationSite"
     - "Package.swift"
     - "Project.swift"
     - "Tuist/**/*.swift"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `./GeneratingDocumentationSite` builds the package, emits symbol graphs, converts `Sources/LaunchingView/LaunchingView.docc`, transforms the archive into static `docs/`, and removes temporary DocC artifacts afterward.
 - Do not commit generated DocC output. `docs/` and `LaunchingView.doccarchive/` are local/CI artifacts.
 - The `Deploy DocC` GitHub Actions workflow publishes generated documentation to `swift-man/docs` under `LaunchingView/`.
+- `swift-man/docs` uses the `docs.gorani.me` custom domain, so DocC static hosting base path should remain `LaunchingView`, not `docs/LaunchingView`.
 - Configure `DOCS_DEPLOY_KEY` with a private deploy key in this repository, and add the matching public key with write access to `swift-man/docs`.
 
 ## Pull Request Review Handling

--- a/GeneratingDocumentationSite
+++ b/GeneratingDocumentationSite
@@ -7,7 +7,7 @@ SYMBOL_GRAPH_PATH="${SYMBOL_GRAPH_PATH:-$PACKAGE_BUILD_PATH/docc-symbolgraphs}"
 DOCC_CATALOG_PATH="${DOCC_CATALOG_PATH:-Sources/$TARGET_NAME/$TARGET_NAME.docc}"
 DOCC_ARCHIVE_PATH="${DOCC_ARCHIVE_PATH:-./$TARGET_NAME.doccarchive}"
 DOCS_OUTPUT_PATH="${DOCS_OUTPUT_PATH:-./docs}"
-HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-docs/$TARGET_NAME}"
+HOSTING_BASE_PATH="${HOSTING_BASE_PATH:-$TARGET_NAME}"
 BUNDLE_IDENTIFIER="${BUNDLE_IDENTIFIER:-com.swift-man.$TARGET_NAME}"
 BUNDLE_VERSION="${BUNDLE_VERSION:-0.9.0}"
 MINIMUM_ACCESS_LEVEL="${MINIMUM_ACCESS_LEVEL:-public}"
@@ -41,6 +41,17 @@ fi
   transform-for-static-hosting "$DOCC_ARCHIVE_PATH" \
   --output-path "$DOCS_OUTPUT_PATH" \
   --hosting-base-path "$HOSTING_BASE_PATH"
+
+HOSTING_BASE_PATH="/${HOSTING_BASE_PATH#/}"
+export HOSTING_BASE_PATH
+perl -0pi -e '
+  my $base = $ENV{"HOSTING_BASE_PATH"};
+  s#href="/favicon\.ico"#href="$base/favicon.ico"#g;
+  s#href="/favicon\.svg"#href="$base/favicon.svg"#g;
+  s#var baseUrl = "/"#var baseUrl = "$base/"#g;
+  s#src="/js/#src="$base/js/#g;
+  s#href="/css/#href="$base/css/#g;
+' "$DOCS_OUTPUT_PATH/index.html"
 
 find "$DOCS_OUTPUT_PATH" -type f -name '*.js' \
   -exec perl -0pi -e 's/[ \t]+$//mg' {} +

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This is a SwiftUI view based on [The Composable Architecture](https://github.com
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)
 
 ---
-### Document Web Site
-[LaunchingView](https://swift-man.github.io/docs/LaunchingView/documentation/launchingview/)
+### Documentation Website
+[LaunchingView](https://docs.gorani.me/LaunchingView/documentation/launchingview/)
 
 ## Feature
 * [x] AsyncLaunchingView
@@ -91,7 +91,7 @@ struct YourApp: App {
 ## Dependencies
 [LaunchingService](https://github.com/swift-man/LaunchingService) calls api using [FirebaseRemoteConfig](https://github.com/firebase/firebase-ios-sdk).
 
-### Custom Your Keys
+### Customize Your Keys
 ```swift
 import Dependencies
 import LaunchingService
@@ -101,7 +101,7 @@ extension RemoteConfigRegisterdKeys: DependencyKey {
 }
 ```
 
-### Custom Your Alert Default Text
+### Customize Your Alert Default Text
 
 ```swift
 import Dependencies


### PR DESCRIPTION
## 변경 사항
- DocC static hosting base path 기본값을 `docs/LaunchingView`에서 `LaunchingView`로 변경했습니다.
- `swift-man/docs`가 `docs.gorani.me` custom domain으로 서비스되는 점을 AGENTS.md에 문서화했습니다.
- README 문서 링크를 실제 custom domain URL인 `https://docs.gorani.me/LaunchingView/documentation/launchingview/`로 갱신했습니다.
- DocC가 생성하는 root `index.html`의 asset 경로도 `/LaunchingView/...`를 사용하도록 후처리했습니다.

## 이유
PR #11 머지 후 `swift-man/docs`로 문서 배포는 성공했지만, Pages가 `docs.gorani.me` custom domain을 쓰면서 `https://swift-man.github.io/docs/...` 요청이 `https://docs.gorani.me/...`로 리다이렉트됩니다.

이 상태에서 DocC base path가 `docs/LaunchingView`이면 문서 HTML이 `/docs/LaunchingView/js/...`를 참조하고, custom domain에서는 해당 경로가 404가 됩니다. 실제 배포 위치가 custom domain 루트의 `/LaunchingView`이므로 base path도 `LaunchingView`가 맞습니다.

## 검증
- `./GeneratingDocumentationSite`
- generated `docs/index.html`과 `docs/documentation/launchingview/index.html`이 `/LaunchingView/...` asset 경로를 사용하는지 확인
- `sh -n GeneratingDocumentationSite`
- `.github/workflows/deploy-docc.yml` YAML 파싱 확인
- `swift test`
- `git diff --check`
