### PR TITLE
[codex] LaunchingService 0.9.0 버전 의존성 적용

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
       }
     },
     {
-      "identity" : "boringssl-swiftpm",
+      "identity" : "app-check",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
       }
     },
     {
@@ -32,8 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "0df86ea17d5d281415be74f2290df8431644f156",
-        "version" : "10.4.0"
+        "revision" : "d10045cace0b4c335c4efa8f7df7e9a9fc5a7c60",
+        "version" : "12.13.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
+        "version" : "3.5.0"
       }
     },
     {
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "9a09ece724128e8d1e14c5133b87c0e236844ac0",
-        "version" : "10.4.0"
+        "revision" : "c2c76bebcfbb90d90ea10599f934f9af160e1604",
+        "version" : "12.13.0"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
-        "version" : "9.2.1"
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
       }
     },
     {
@@ -59,17 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
-        "version" : "7.11.0"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
       }
     },
     {
@@ -77,8 +86,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "96d7cc73a71ce950723aa3c50ce4fb275ae180b8",
-        "version" : "3.1.0"
+        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {
@@ -86,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-man/LaunchingService",
       "state" : {
-        "branch" : "main",
-        "revision" : "4208b563f6631b197328ea3e664f96f582ad14d3"
+        "revision" : "549c42e369981481a29066b384f866a954cde82a",
+        "version" : "0.9.0"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
-        "version" : "2.30909.0"
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
-        "version" : "2.1.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -178,15 +196,6 @@
       "state" : {
         "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
         "version" : "0.6.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
-        "version" : "1.20.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
       .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.50.1"),
-      .package(url: "https://github.com/swift-man/LaunchingService", branch: "main"),
+      .package(url: "https://github.com/swift-man/LaunchingService", from: "0.9.0"),
     ],
     targets: [
         .target(

--- a/Sources/LaunchingView/Public/LaunchingAlertDefaultText.swift
+++ b/Sources/LaunchingView/Public/LaunchingAlertDefaultText.swift
@@ -11,12 +11,12 @@ import Foundation
 @available(iOS 15.0, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-public struct LaunchingAlertDefaultText {
+public struct LaunchingAlertDefaultText: Sendable {
   
   @available(iOS 15.0, macOS 12, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public struct ForceUpdate {
+  public struct ForceUpdate: Sendable {
     let title: String
     let message: String
     let done: String
@@ -33,7 +33,7 @@ public struct LaunchingAlertDefaultText {
   @available(iOS 15.0, macOS 12, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public struct OptionalUpdate {
+  public struct OptionalUpdate: Sendable {
     let title: String
     let message: String
     let cancel: String
@@ -53,7 +53,7 @@ public struct LaunchingAlertDefaultText {
   @available(iOS 15.0, macOS 12, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public struct Notice {
+  public struct Notice: Sendable {
     let title: String
     let message: String
     let cancel: String

--- a/Sources/LaunchingView/Public/LaunchingService+.swift
+++ b/Sources/LaunchingView/Public/LaunchingService+.swift
@@ -12,8 +12,8 @@ import LaunchingService
 @available(iOS 15.0, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension LaunchingService: DependencyKey {
-   public static var liveValue = LaunchingService()
+extension LaunchingService: @retroactive DependencyKey {
+  public static let liveValue = LaunchingService()
 }
 
 @available(iOS 15.0, macOS 12, *)

--- a/Sources/LaunchingView/Public/LaunchingService+.swift
+++ b/Sources/LaunchingView/Public/LaunchingService+.swift
@@ -12,16 +12,28 @@ import LaunchingService
 @available(iOS 15.0, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension LaunchingService: @retroactive DependencyKey {
-  public static let liveValue = LaunchingService()
+private enum LaunchingServiceKey: DependencyKey {
+  public static let liveValue: any LaunchingInteractable = LaunchingService()
+  public static let testValue: any LaunchingInteractable = UnimplementedLaunchingService()
+}
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private final class UnimplementedLaunchingService: LaunchingInteractable {
+  func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
+    let fetch: @Sendable () async throws -> AppUpdateStatus =
+      unimplemented(#"@Dependency(\.launchingService).fetchAppUpdateStatus"#)
+    return try await fetch()
+  }
 }
 
 @available(iOS 15.0, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension DependencyValues {
-  var launchingService: LaunchingService {
-    get { self[LaunchingService.self] }
-    set { self[LaunchingService.self] = newValue }
+  var launchingService: any LaunchingInteractable {
+    get { self[LaunchingServiceKey.self] }
+    set { self[LaunchingServiceKey.self] = newValue }
   }
 }

--- a/Sources/LaunchingView/Public/SharedURL.swift
+++ b/Sources/LaunchingView/Public/SharedURL.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @available(iOS 15.0, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-public struct SharedURL {
+public struct SharedURL: Sendable {
   public static let shared = SharedURL()
   private init() {}
   

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -1,9 +1,12 @@
 import SwiftUI
-import XCTest
+import Testing
 @testable import LaunchingView
 
-final class LaunchingViewTests: XCTestCase {
-  func testLaunchingViewInitializesWithDefaultCompletionState() {
+@Suite("LaunchingView")
+@MainActor
+struct LaunchingViewTests {
+  @Test
+  func launchingViewInitializesWithDefaultCompletionState() {
     let view = LaunchingView(
       content: {
         Text("Content")
@@ -13,10 +16,11 @@ final class LaunchingViewTests: XCTestCase {
       }
     )
 
-    XCTAssertFalse(String(describing: type(of: view)).isEmpty)
+    #expect(!String(describing: type(of: view)).isEmpty)
   }
 
-  func testLaunchingViewInitializesWithCustomCompletionState() {
+  @Test
+  func launchingViewInitializesWithCustomCompletionState() {
     let view = LaunchingView(
       content: {
         Text("Content")
@@ -27,18 +31,20 @@ final class LaunchingViewTests: XCTestCase {
       isFinished: .constant(false)
     )
 
-    XCTAssertFalse(String(describing: type(of: view)).isEmpty)
+    #expect(!String(describing: type(of: view)).isEmpty)
   }
 
-  func testAsyncLaunchingViewInitializes() {
+  @Test
+  func asyncLaunchingViewInitializes() {
     let view = AsyncLaunchingView {
       Text("Content")
     }
 
-    XCTAssertFalse(String(describing: type(of: view)).isEmpty)
+    #expect(!String(describing: type(of: view)).isEmpty)
   }
 
-  func testLaunchingAlertDefaultTextCanBeCustomized() {
+  @Test
+  func launchingAlertDefaultTextCanBeCustomized() {
     let defaultText = LaunchingAlertDefaultText(
       forceUpdate: .init(
         title: "Force update",
@@ -59,10 +65,10 @@ final class LaunchingViewTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(defaultText.forceUpdate.title, "Force update")
-    XCTAssertEqual(defaultText.forceUpdate.message, "Please update now")
-    XCTAssertEqual(defaultText.forceUpdate.done, "Update")
-    XCTAssertEqual(defaultText.optionalUpdate.cancel, "Later")
-    XCTAssertEqual(defaultText.notice.done, "Open")
+    #expect(defaultText.forceUpdate.title == "Force update")
+    #expect(defaultText.forceUpdate.message == "Please update now")
+    #expect(defaultText.forceUpdate.done == "Update")
+    #expect(defaultText.optionalUpdate.cancel == "Later")
+    #expect(defaultText.notice.done == "Open")
   }
 }


### PR DESCRIPTION
## 변경 사항
- LaunchingService 의존성을 `branch: "main"`에서 `from: "0.9.0"`으로 변경했습니다.
- LaunchingView를 `from: "0.9.0"` 형태의 stable version dependency로 소비할 때 SwiftPM의 branch dependency 제한에 걸리지 않도록 했습니다.
- `swift package resolve`를 통해 `Package.resolved`를 재계산했습니다.
- XCTest 기반 테스트를 Swift Testing의 `@Suite`, `@Test`, `#expect` 형식으로 전환했습니다.
- Swift Testing 사용을 명확히 하기 위해 `swift-tools-version`을 `6.0`으로 올렸습니다.
- Swift 6 strict concurrency 빌드를 위해 `LaunchingAlertDefaultText`, `SharedURL`에 `Sendable`을 명시했습니다.
- `launchingService` dependency를 concrete `LaunchingService`에서 `any LaunchingInteractable` 기반 key로 바꾸고, 테스트 기본값을 `unimplemented` 구현으로 격리했습니다.

## 참고
- `LaunchingService 0.9.0` 태그 존재를 확인했습니다.
- `Package.resolved`에서 Firebase 계열 transitive dependency가 `LaunchingService 0.9.0`의 `firebase-ios-sdk from: 12.13.0` 조건에 맞춰 갱신됐습니다.
- 플랫폼 최소 버전(iOS 15, macOS 12)은 변경하지 않았고, Swift tools 최소 버전만 Swift Testing에 맞춰 올렸습니다.
- URL open, app termination side effect를 reducer 밖으로 분리하는 작업은 별도 구조 개선 PR로 분리하는 것이 안전합니다.

## 검증
- `git ls-remote --tags https://github.com/swift-man/LaunchingService.git refs/tags/0.9.0`
- `swift package resolve`
- `swift test`
- `git diff --check`
- `rg -n 'branch:|"branch"' Package.swift Package.resolved`
- `rg -n 'XCTest|XCTAssert|XCTestCase' Tests Sources Package.swift`
