### PR TITLE
[codex] Launching side effect 의존성 격리

### DIFF
--- a/Sources/LaunchingView/Private/AppTerminationDelay.swift
+++ b/Sources/LaunchingView/Private/AppTerminationDelay.swift
@@ -12,10 +12,10 @@ import Foundation
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 struct AppTerminationDelay: Sendable {
-  var sleep: @Sendable () async -> Void
+  var sleep: @Sendable () async throws -> Void
 
-  func callAsFunction() async {
-    await sleep()
+  func callAsFunction() async throws {
+    try await sleep()
   }
 }
 
@@ -24,7 +24,7 @@ struct AppTerminationDelay: Sendable {
 @available(watchOS, unavailable)
 private enum AppTerminationDelayKey: DependencyKey {
   static let liveValue = AppTerminationDelay {
-    try? await Task.sleep(nanoseconds: 200_000_000)
+    try await Task.sleep(nanoseconds: 200_000_000)
   }
 
   static let testValue = AppTerminationDelay {

--- a/Sources/LaunchingView/Private/AppTerminationDelay.swift
+++ b/Sources/LaunchingView/Private/AppTerminationDelay.swift
@@ -1,0 +1,44 @@
+//
+//  AppTerminationDelay.swift
+//
+//
+//  Created by SwiftMan on 2026/05/17.
+//
+
+import Dependencies
+import Foundation
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct AppTerminationDelay: Sendable {
+  var sleep: @Sendable () async -> Void
+
+  func callAsFunction() async {
+    await sleep()
+  }
+}
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private enum AppTerminationDelayKey: DependencyKey {
+  static let liveValue = AppTerminationDelay {
+    try? await Task.sleep(nanoseconds: 200_000_000)
+  }
+
+  static let testValue = AppTerminationDelay {
+    let sleep: @Sendable () -> Void = unimplemented(#"@Dependency(\.appTerminationDelay)"#)
+    sleep()
+  }
+}
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension DependencyValues {
+  var appTerminationDelay: AppTerminationDelay {
+    get { self[AppTerminationDelayKey.self] }
+    set { self[AppTerminationDelayKey.self] = newValue }
+  }
+}

--- a/Sources/LaunchingView/Private/AppTerminator.swift
+++ b/Sources/LaunchingView/Private/AppTerminator.swift
@@ -1,0 +1,46 @@
+//
+//  AppTerminator.swift
+//
+//
+//  Created by SwiftMan on 2026/05/17.
+//
+
+import Darwin
+import Dependencies
+import Foundation
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct AppTerminator: Sendable {
+  var terminate: @Sendable () async -> Void
+
+  func callAsFunction() async {
+    await terminate()
+  }
+}
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private enum AppTerminatorKey: DependencyKey {
+  static let liveValue = AppTerminator {
+    try? await Task.sleep(nanoseconds: 200_000_000)
+    Darwin.exit(0)
+  }
+
+  static let testValue = AppTerminator {
+    let terminate: @Sendable () -> Void = unimplemented(#"@Dependency(\.appTerminator)"#)
+    terminate()
+  }
+}
+
+@available(iOS 15.0, macOS 12, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension DependencyValues {
+  var appTerminator: AppTerminator {
+    get { self[AppTerminatorKey.self] }
+    set { self[AppTerminatorKey.self] = newValue }
+  }
+}

--- a/Sources/LaunchingView/Private/AppTerminator.swift
+++ b/Sources/LaunchingView/Private/AppTerminator.swift
@@ -25,7 +25,6 @@ struct AppTerminator: Sendable {
 @available(watchOS, unavailable)
 private enum AppTerminatorKey: DependencyKey {
   static let liveValue = AppTerminator {
-    try? await Task.sleep(nanoseconds: 200_000_000)
     Darwin.exit(0)
   }
 

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -68,6 +68,9 @@ struct Launching: ReducerProtocol {
 
   @Dependency(\.appTerminator)
   var appTerminator
+
+  @Dependency(\.appTerminationDelay)
+  var appTerminationDelay
   
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
@@ -201,13 +204,15 @@ struct Launching: ReducerProtocol {
 
     let openURL = self.openURL
     let appTerminator = self.appTerminator
+    let appTerminationDelay = self.appTerminationDelay
 
-    return .fireAndForget {
+    return .run { _ in
       if let url {
         await openURL(url)
       }
 
       if terminatesApp {
+        await appTerminationDelay()
         await appTerminator()
       }
     }

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -87,6 +87,7 @@ struct Launching: ReducerProtocol {
         }
       }
     case .forceUpdateAlertDismissed:
+      state.forceUpdateAlert = nil
       guard let appUpdateStatus = state.appUpdateStatus else { return .none }
       
       switch appUpdateStatus {

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -101,15 +101,13 @@ struct Launching: ReducerProtocol {
       state.optionalUpdateAlert = nil
       return .none
       
-    case .optionalUpdateAlertDoneTapped:
-      guard let appUpdateStatus = state.appUpdateStatus else { return .none }
-      
-      switch appUpdateStatus {
-      case .valid, .forcedUpdateRequired, .notice:
+    case .optionalUpdateAlertDoneTapped(let appStoreURL):
+      switch state.appUpdateStatus {
+      case .valid, .forcedUpdateRequired, .notice, nil:
         return .none
         
-      case .optionalUpdateRequired(let updateAlert):
-        return performExternalAction(url: updateAlert.alertDoneLinkURL)
+      case .optionalUpdateRequired:
+        return performExternalAction(url: appStoreURL)
       }
       
     case .setAppUpdateStatus(let appVersionStatus):

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -62,6 +62,12 @@ struct Launching: ReducerProtocol {
   
   @Dependency(\.launchingAlertDefaultText)
   var launchingAlertDefaultText
+
+  @Dependency(\.openURL)
+  var openURL
+
+  @Dependency(\.appTerminator)
+  var appTerminator
   
   func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
     switch action {
@@ -85,12 +91,10 @@ struct Launching: ReducerProtocol {
         return .none
         
       case .forcedUpdateRequired(let updateAlert):
-        SharedURL.shared.open(updateAlert.alertDoneLinkURL)
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
-          exit(0)
-        })
-        return .none
+        return performExternalAction(
+          url: updateAlert.alertDoneLinkURL,
+          terminatesApp: true
+        )
       }
       
     case .optionalUpdateAlertDismissed:
@@ -105,8 +109,7 @@ struct Launching: ReducerProtocol {
         return .none
         
       case .optionalUpdateRequired(let updateAlert):
-        SharedURL.shared.open(updateAlert.alertDoneLinkURL)
-        return .none
+        return performExternalAction(url: updateAlert.alertDoneLinkURL)
       }
       
     case .setAppUpdateStatus(let appVersionStatus):
@@ -184,16 +187,30 @@ struct Launching: ReducerProtocol {
         return .none
         
       case .notice(let noticeAlert):
-        if let url = noticeAlert.doneURL {
-          SharedURL.shared.open(url)
-        }
-        
-        if noticeAlert.isAppTerminated {
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
-            exit(0)
-          })
-        }
-        return .none
+        return performExternalAction(
+          url: noticeAlert.doneURL,
+          terminatesApp: noticeAlert.isAppTerminated
+        )
+      }
+    }
+  }
+
+  private func performExternalAction(
+    url: URL?,
+    terminatesApp: Bool = false
+  ) -> EffectTask<Action> {
+    guard url != nil || terminatesApp else { return .none }
+
+    let openURL = self.openURL
+    let appTerminator = self.appTerminator
+
+    return .fireAndForget {
+      if let url {
+        await openURL(url)
+      }
+
+      if terminatesApp {
+        await appTerminator()
       }
     }
   }

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -213,7 +213,7 @@ struct Launching: ReducerProtocol {
       }
 
       if terminatesApp {
-        await appTerminationDelay()
+        try await appTerminationDelay()
         await appTerminator()
       }
     }

--- a/Sources/LaunchingView/Public/SharedURL.swift
+++ b/Sources/LaunchingView/Public/SharedURL.swift
@@ -22,7 +22,11 @@ public struct SharedURL: Sendable {
   )
   public func open(_ url: URL) {
     Task { @MainActor in
-      EnvironmentValues().openURL(url)
+      #if os(iOS)
+        UIApplication.shared.open(url)
+      #elseif os(macOS)
+        NSWorkspace.shared.open(url)
+      #endif
     }
   }
 

--- a/Sources/LaunchingView/Public/SharedURL.swift
+++ b/Sources/LaunchingView/Public/SharedURL.swift
@@ -14,10 +14,20 @@ import SwiftUI
 public struct SharedURL: Sendable {
   public static let shared = SharedURL()
   private init() {}
-  
+
+  @available(
+    *,
+    deprecated,
+    message: "Prefer SwiftUI's @Environment(\\.openURL) or TCA's @Dependency(\\.openURL)."
+  )
   public func open(_ url: URL) {
     Task { @MainActor in
       EnvironmentValues().openURL(url)
     }
+  }
+
+  @MainActor
+  public func open(_ url: URL, using openURL: OpenURLAction) {
+    openURL(url)
   }
 }

--- a/Sources/LaunchingView/Public/SharedURL.swift
+++ b/Sources/LaunchingView/Public/SharedURL.swift
@@ -16,10 +16,8 @@ public struct SharedURL: Sendable {
   private init() {}
   
   public func open(_ url: URL) {
-#if os(iOS)
-        UIApplication.shared.open(url)
-#else
-        NSWorkspace.shared.open(url)
-#endif
+    Task { @MainActor in
+      EnvironmentValues().openURL(url)
+    }
   }
 }

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -98,6 +98,7 @@ struct LaunchingViewTests {
     store.dependencies.appTerminator = AppTerminator {
       await recorder.terminate()
     }
+    store.dependencies.appTerminationDelay = AppTerminationDelay {}
 
     await store.send(.optionalUpdateAlertDoneTapped(appStoreURL: actionURL)).finish()
 
@@ -128,6 +129,7 @@ struct LaunchingViewTests {
     store.dependencies.appTerminator = AppTerminator {
       await recorder.terminate()
     }
+    store.dependencies.appTerminationDelay = AppTerminationDelay {}
 
     await store.send(.forceUpdateAlertDismissed).finish()
 
@@ -159,6 +161,7 @@ struct LaunchingViewTests {
     store.dependencies.appTerminator = AppTerminator {
       await recorder.terminate()
     }
+    store.dependencies.appTerminationDelay = AppTerminationDelay {}
 
     await store.send(.noticeAlertDismissed).finish()
 

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -118,7 +118,10 @@ struct LaunchingViewTests {
             message: "",
             alertDoneLinkURL: url
           )
-        )
+        ),
+        forceUpdateAlert: AlertState {
+          TextState("Force update")
+        }
       ),
       reducer: Launching()
     )
@@ -131,7 +134,9 @@ struct LaunchingViewTests {
     }
     store.dependencies.appTerminationDelay = AppTerminationDelay {}
 
-    await store.send(.forceUpdateAlertDismissed).finish()
+    await store.send(.forceUpdateAlertDismissed) {
+      $0.forceUpdateAlert = nil
+    }.finish()
 
     #expect(await recorder.openedURLs() == [url])
     #expect(await recorder.terminateCount() == 1)

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+import LaunchingService
 import SwiftUI
 import Testing
 @testable import LaunchingView
@@ -70,5 +72,117 @@ struct LaunchingViewTests {
     #expect(defaultText.forceUpdate.done == "Update")
     #expect(defaultText.optionalUpdate.cancel == "Later")
     #expect(defaultText.notice.done == "Open")
+  }
+
+  @Test
+  func optionalUpdateDoneOpensUpdateURL() async {
+    let url = URL(string: "https://example.com/optional")!
+    let recorder = ExternalActionRecorder()
+    let store = TestStore(
+      initialState: Launching.State(
+        appUpdateStatus: .optionalUpdateRequired(
+          UpdateAlert(
+            title: "",
+            message: "",
+            alertDoneLinkURL: url
+          )
+        )
+      ),
+      reducer: Launching()
+    )
+    store.dependencies.openURL = OpenURLEffect { url in
+      await recorder.open(url)
+      return true
+    }
+    store.dependencies.appTerminator = AppTerminator {
+      await recorder.terminate()
+    }
+
+    await store.send(.optionalUpdateAlertDoneTapped(appStoreURL: url)).finish()
+
+    #expect(await recorder.openedURLs() == [url])
+    #expect(await recorder.terminateCount() == 0)
+  }
+
+  @Test
+  func forceUpdateDismissalOpensURLAndTerminatesApp() async {
+    let url = URL(string: "https://example.com/force")!
+    let recorder = ExternalActionRecorder()
+    let store = TestStore(
+      initialState: Launching.State(
+        appUpdateStatus: .forcedUpdateRequired(
+          UpdateAlert(
+            title: "",
+            message: "",
+            alertDoneLinkURL: url
+          )
+        )
+      ),
+      reducer: Launching()
+    )
+    store.dependencies.openURL = OpenURLEffect { url in
+      await recorder.open(url)
+      return true
+    }
+    store.dependencies.appTerminator = AppTerminator {
+      await recorder.terminate()
+    }
+
+    await store.send(.forceUpdateAlertDismissed).finish()
+
+    #expect(await recorder.openedURLs() == [url])
+    #expect(await recorder.terminateCount() == 1)
+  }
+
+  @Test
+  func terminatingNoticeDismissalOpensURLAndTerminatesApp() async {
+    let url = URL(string: "https://example.com/notice")!
+    let recorder = ExternalActionRecorder()
+    let store = TestStore(
+      initialState: Launching.State(
+        appUpdateStatus: .notice(
+          NoticeAlert(
+            title: "",
+            message: "",
+            isAppTerminated: true,
+            doneURL: url
+          )
+        )
+      ),
+      reducer: Launching()
+    )
+    store.dependencies.openURL = OpenURLEffect { url in
+      await recorder.open(url)
+      return true
+    }
+    store.dependencies.appTerminator = AppTerminator {
+      await recorder.terminate()
+    }
+
+    await store.send(.noticeAlertDismissed).finish()
+
+    #expect(await recorder.openedURLs() == [url])
+    #expect(await recorder.terminateCount() == 1)
+  }
+}
+
+private actor ExternalActionRecorder {
+  private var urls: [URL] = []
+  private var terminations = 0
+
+  func open(_ url: URL) {
+    urls.append(url)
+  }
+
+  func terminate() {
+    terminations += 1
+  }
+
+  func openedURLs() -> [URL] {
+    urls
+  }
+
+  func terminateCount() -> Int {
+    terminations
   }
 }

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -75,8 +75,9 @@ struct LaunchingViewTests {
   }
 
   @Test
-  func optionalUpdateDoneOpensUpdateURL() async {
-    let url = URL(string: "https://example.com/optional")!
+  func optionalUpdateDoneOpensActionURL() async {
+    let stateURL = URL(string: "https://example.com/state-optional")!
+    let actionURL = URL(string: "https://example.com/action-optional")!
     let recorder = ExternalActionRecorder()
     let store = TestStore(
       initialState: Launching.State(
@@ -84,7 +85,7 @@ struct LaunchingViewTests {
           UpdateAlert(
             title: "",
             message: "",
-            alertDoneLinkURL: url
+            alertDoneLinkURL: stateURL
           )
         )
       ),
@@ -98,9 +99,9 @@ struct LaunchingViewTests {
       await recorder.terminate()
     }
 
-    await store.send(.optionalUpdateAlertDoneTapped(appStoreURL: url)).finish()
+    await store.send(.optionalUpdateAlertDoneTapped(appStoreURL: actionURL)).finish()
 
-    #expect(await recorder.openedURLs() == [url])
+    #expect(await recorder.openedURLs() == [actionURL])
     #expect(await recorder.terminateCount() == 0)
   }
 


### PR DESCRIPTION
## 변경 사항
- `Launching` reducer에서 `SharedURL.shared.open`, `DispatchQueue.main.asyncAfter`, `exit(0)` 직접 호출을 제거했습니다.
- URL open은 TCA Dependencies의 `openURL` dependency를 통해 `.run` effect 안에서 실행하도록 변경했습니다.
- 앱 종료는 `AppTerminator` dependency로 캡슐화하고, 종료 전 지연은 `AppTerminationDelay` dependency로 분리해 테스트에서 제어할 수 있도록 했습니다.
- `optionalUpdateAlertDoneTapped(appStoreURL:)`가 상태 URL 대신 액션 payload URL을 사용하도록 수정했습니다.
- `forceUpdateAlertDismissed`에서 `forceUpdateAlert` 상태를 명시적으로 정리하도록 보강했습니다.
- 기존 public `SharedURL.open(_:)`은 호환을 위해 유지하되 deprecated 처리하고, `OpenURLAction`을 주입받는 대체 overload를 추가했습니다.
- Swift Testing + `TestStore` 테스트를 추가/보강해 optional update, forced update, terminating notice의 URL open 및 termination 동작을 mock dependency로 검증했습니다.

## 리뷰봇 반영 상태
- codex-review-bot의 optional update payload 미사용 지적은 수정 완료했습니다.
- gemini-pr-review-bot의 `fireAndForget` 권고는 `.run` 전환으로 반영했습니다.
- 종료 지연 하드코딩 지적은 `AppTerminationDelay` dependency로 분리해 반영했습니다. `ContinuousClock`은 현재 최소 지원(iOS 15/macOS 12)과 TCA 0.50의 availability 제약 때문에 적용하지 않았습니다.
- `EnvironmentValues()` 직접 생성 지적은 제거했고, reducer 경로는 `@Dependency(\.openURL)`, public helper는 deprecated + `OpenURLAction` overload로 정리했습니다.
- `Darwin.exit(0)` 제거 권고는 기존 `isAppTerminated` 동작을 바꾸는 API/UX 변경이라 이번 PR에서는 dependency로 격리하는 선에서 유지했습니다. 입력 차단형 blocking view 전환은 별도 설계 PR로 다루는 편이 안전합니다.

## PR 구조
- 이 PR은 PR #14 위에 쌓은 후속 PR입니다.
- PR #14가 main에 머지되면 이 PR의 base를 main으로 변경하면 됩니다.
- 현재 workflow는 `pull_request` base가 `main`일 때만 실행되어 stacked PR 상태에서는 GitHub Actions check가 붙지 않습니다.

## 검증
- `swift build`
- `swift test`
- `git diff --check`
- `rg -n 'EnvironmentValues\\(\\)|SharedURL\\.shared|UIApplication\\.shared|NSWorkspace\\.shared|DispatchQueue\\.main\\.asyncAfter|exit\\(|fireAndForget|Task\\.sleep' Sources/LaunchingView Tests`
