### PR TITLE
[codex] 차단 화면 리뷰 후속 테스트 보강

### DIFF
--- a/Sources/LaunchingView/Private/BlockingLaunchView.swift
+++ b/Sources/LaunchingView/Private/BlockingLaunchView.swift
@@ -40,7 +40,7 @@ struct BlockingLaunchView: View {
         }
       }
 
-      if linkURL != nil {
+      if let linkURL {
         Button {
           onButtonTapped(linkURL)
         } label: {

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -182,7 +182,7 @@ struct LaunchingViewTests {
   }
 
   @Test
-  func fetchWhileFetchingMarksPendingRefresh() {
+  func fetchWhileFetchingRefreshesAgainAfterCurrentStatusFinishes() async {
     let url = URL(string: "https://example.com/force")!
     let forceStatus = AppUpdateStatus.forcedUpdateRequired(
       UpdateAlert(
@@ -191,33 +191,56 @@ struct LaunchingViewTests {
         alertDoneLinkURL: url
       )
     )
-    var state = Launching.State(isFetching: true)
-    let reducer = Launching()
+    let store = TestStore(
+      initialState: Launching.State(isFetching: true),
+      reducer: Launching()
+    )
+    store.dependencies.launchingAlertDefaultText = LaunchingAlertDefaultText(
+      forceUpdate: .init(done: "Update")
+    )
+    store.dependencies.launchingService = StubLaunchingService(status: .valid)
 
-    _ = reducer.reduce(into: &state, action: .fetchAppUpdateStatus)
-
-    #expect(state.hasPendingFetch)
-
-    withDependencies {
-      $0.launchingAlertDefaultText = LaunchingAlertDefaultText(
-        forceUpdate: .init(done: "Update")
-      )
-    } operation: {
-      _ = reducer.reduce(into: &state, action: .setAppUpdateStatus(forceStatus))
+    await store.send(.fetchAppUpdateStatus) {
+      $0.hasPendingFetch = true
     }
 
-    #expect(!state.isFetching)
-    #expect(!state.hasPendingFetch)
-    #expect(state.appUpdateStatus == forceStatus)
-    #expect(state.displayContentView == false)
-    #expect(
-      state.blockingAlert == Launching.State.BlockingAlert(
+    await store.send(.setAppUpdateStatus(forceStatus)) {
+      $0.isFetching = false
+      $0.hasPendingFetch = false
+      $0.appUpdateStatus = forceStatus
+      $0.displayContentView = false
+      $0.blockingAlert = Launching.State.BlockingAlert(
         title: "Force update",
         message: "Please update now",
         buttonTitle: "Update",
         linkURL: url
       )
-    )
+    }
+
+    await store.receive(.fetchAppUpdateStatus) {
+      $0.isFetching = true
+    }
+
+    await store.receive(.setAppUpdateStatus(.valid)) {
+      $0.isFetching = false
+      $0.appUpdateStatus = .valid
+      $0.displayContentView = true
+      $0.blockingAlert = nil
+      $0.optionalUpdateAlert = nil
+      $0.noticeAlert = nil
+    }
+  }
+}
+
+private final class StubLaunchingService: LaunchingInteractable {
+  private let status: AppUpdateStatus
+
+  init(status: AppUpdateStatus) {
+    self.status = status
+  }
+
+  func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
+    status
   }
 }
 


### PR DESCRIPTION
## 변경 사항
- `BlockingLaunchView`의 버튼 표시 조건을 `linkURL != nil` 비교에서 `if let linkURL` 옵셔널 바인딩으로 정리했습니다.
- pending fetch 테스트를 reducer 직접 호출 방식에서 `TestStore` 기반 검증으로 보강했습니다.
- 진행 중 fetch가 있을 때 후속 요청을 pending으로 기록하고, 현재 상태 처리 후 `.fetchAppUpdateStatus` effect가 실제로 방출되는지 확인합니다.
- stubbed `LaunchingService` 응답까지 이어 받아 `.valid` 상태 전환을 검증하도록 했습니다.

## 리뷰 반영
- Gemini 리뷰의 `BlockingLaunchView` 옵셔널 바인딩 제안을 반영했습니다.
- Codex 리뷰의 pending fetch 후속 effect 검증 공백을 후속 PR에서 보완했습니다.
- `.cancellable(id:cancelInFlight:)` 전환 제안은 기존 요청을 취소하지 않고 완료 후 재조회하는 현재 동작 의미와 달라질 수 있어 이번 PR에는 포함하지 않았습니다.

## 의존성 메모
- TCA 1.x 업데이트는 현재 `LaunchingService`가 `swift-dependencies 0.x` 범위를 요구해 바로 진행할 수 없습니다.
- `LaunchingService`가 `swift-dependencies >= 1.4.0`을 지원하는 버전으로 갱신된 뒤 별도 의존성 PR에서 TCA 최신화와 API 마이그레이션을 진행하는 것이 안전합니다.

## 검증
- `swift build`
- `swift test`
- `git diff --check`