### PR TITLE
[codex] LaunchingService 0.9.2 및 TCA 1.25 반영

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "ed7605a3c32c801fb4f644e54ec6ad83f423357fa849fa21472bd468f6a616f9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -104,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-man/LaunchingService",
       "state" : {
-        "revision" : "549c42e369981481a29066b384f866a954cde82a",
-        "version" : "0.9.0"
+        "revision" : "88d9ee3debca4408c0c916cd0ffd8560aa18111c",
+        "version" : "0.9.2"
       }
     },
     {
@@ -140,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
-        "version" : "0.11.0"
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
       }
     },
     {
@@ -149,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -158,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -167,8 +168,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "b690a617d1366bd36f047e5da5d3185f20daac71",
-        "version" : "0.50.1"
+        "revision" : "df934d9c5a274a6f6a7bdcec73fbcb330149ff8b",
+        "version" : "1.23.2"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -176,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "87dd388a193569b288d03cb4060db54f90d1a66f",
-        "version" : "0.7.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -185,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
-        "version" : "0.1.4"
+        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
+        "version" : "1.11.0"
       }
     },
     {
@@ -194,17 +204,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
-        "version" : "0.6.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
-      "identity" : "swiftui-navigation",
+      "identity" : "swift-navigation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "270a754308f5440be52fc295242eb7031638bd15",
-        "version" : "0.6.1"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -212,10 +249,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed7605a3c32c801fb4f644e54ec6ad83f423357fa849fa21472bd468f6a616f9",
+  "originHash" : "5ea60122b1a916d32bf1b048fcd1377bc7563ce81c7f2e10f0bd68dd64e5a6ef",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "df934d9c5a274a6f6a7bdcec73fbcb330149ff8b",
-        "version" : "1.23.2"
+        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
+        "version" : "1.25.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             targets: ["LaunchingView"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.50.1"),
-      .package(url: "https://github.com/swift-man/LaunchingService", from: "0.9.0"),
+      .package(url: "https://github.com/pointfreeco/swift-composable-architecture", "1.23.2"..<"1.24.0"),
+      .package(url: "https://github.com/swift-man/LaunchingService", from: "0.9.2"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "LaunchingView",
     platforms: [
-      .iOS(.v15),
-      .macOS(.v12),
+      .iOS(.v16),
+      .macOS(.v13),
     ],
     products: [
         .library(
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["LaunchingView"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/pointfreeco/swift-composable-architecture", "1.23.2"..<"1.24.0"),
+      .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.25.5"),
       .package(url: "https://github.com/swift-man/LaunchingService", from: "0.9.2"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a SwiftUI view based on [The Composable Architecture](https://github.com
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
 ![Badge - Version](https://img.shields.io/badge/Version-0.9.1-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-compatible-orange?style=flat-square)
-![Badge - Platform](https://img.shields.io/badge/macOS-v12.0-yellow?style=flat-square)
-![Badge - Platform](https://img.shields.io/badge/iOS-v15.0-yellow?style=flat-square)
+![Badge - Platform](https://img.shields.io/badge/macOS-v13.0-yellow?style=flat-square)
+![Badge - Platform](https://img.shields.io/badge/iOS-v16.0-yellow?style=flat-square)
 ![Badge - License](https://img.shields.io/badge/license-MIT-black?style=flat-square)
 
 ---

--- a/Sources/LaunchingView/Private/BlockingLaunchView.swift
+++ b/Sources/LaunchingView/Private/BlockingLaunchView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 struct BlockingLaunchView: View {

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -115,6 +115,7 @@ struct Launching: Reducer {
       let hasPendingFetch = state.hasPendingFetch
       state.hasPendingFetch = false
       state.appUpdateStatus = appVersionStatus
+      state.appUpdateFetchErrorAlert = nil
       
       switch appVersionStatus {
       case .valid:
@@ -196,6 +197,8 @@ struct Launching: Reducer {
         return .send(.fetchAppUpdateStatus)
       }
       
+      state.optionalUpdateAlert = nil
+      state.noticeAlert = nil
       state.appUpdateFetchErrorAlert = AlertState {
         TextState(Bundle.main.displayName)
       } message: {

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -10,7 +10,7 @@ import ComposableArchitecture
 import SwiftUI
 
 /// Launching은 App 구동을 위한 Request 를 포함한 AppUpdate 상태를 관리합니다.
-struct Launching: ReducerProtocol {
+struct Launching: Reducer {
   // MARK: - Enums
   struct State: Equatable {
     struct BlockingAlert: Equatable {
@@ -75,7 +75,7 @@ struct Launching: ReducerProtocol {
   @Dependency(\.openURL)
   var openURL
   
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+  func reduce(into state: inout State, action: Action) -> Effect<Action> {
     switch action {
     case .fetchAppUpdateStatus:
       guard !state.isFetching else {
@@ -84,12 +84,13 @@ struct Launching: ReducerProtocol {
       }
       
       state.isFetching = true
-      return .task {
+      let launchingService = self.launchingService
+      return .run { send in
         do {
           let appStatus = try await launchingService.fetchAppUpdateStatus()
-          return .setAppUpdateStatus(appStatus)
+          await send(.setAppUpdateStatus(appStatus))
         } catch {
-          return .showFetchErrorAlert(errorMessage: error.localizedDescription)
+          await send(.showFetchErrorAlert(errorMessage: error.localizedDescription))
         }
       }
 
@@ -145,13 +146,18 @@ struct Launching: ReducerProtocol {
         state.displayContentView = true
         state.blockingAlert = nil
         state.noticeAlert = nil
-        state.optionalUpdateAlert = AlertState(
-          title: TextState(title),
-          message: TextState(message),
-          primaryButton: .cancel(TextState(launchingAlertDefaultText.optionalUpdate.cancel)),
-          secondaryButton: .default(TextState(launchingAlertDefaultText.optionalUpdate.done),
-                                    action: .send(.optionalUpdateAlertDoneTapped(appStoreURL: updateAlert.alertDoneLinkURL)))
-        )
+        state.optionalUpdateAlert = AlertState {
+          TextState(title)
+        } actions: {
+          ButtonState(role: .cancel) {
+            TextState(launchingAlertDefaultText.optionalUpdate.cancel)
+          }
+          ButtonState(action: .optionalUpdateAlertDoneTapped(appStoreURL: updateAlert.alertDoneLinkURL)) {
+            TextState(launchingAlertDefaultText.optionalUpdate.done)
+          }
+        } message: {
+          TextState(message)
+        }
         
         return fetchAgainIfNeeded(hasPendingFetch)
         
@@ -217,7 +223,7 @@ struct Launching: ReducerProtocol {
     }
   }
 
-  private func openExternalURL(_ url: URL?) -> EffectTask<Action> {
+  private func openExternalURL(_ url: URL?) -> Effect<Action> {
     guard let url else { return .none }
 
     let openURL = self.openURL
@@ -227,7 +233,7 @@ struct Launching: ReducerProtocol {
     }
   }
 
-  private func fetchAgainIfNeeded(_ hasPendingFetch: Bool) -> EffectTask<Action> {
+  private func fetchAgainIfNeeded(_ hasPendingFetch: Bool) -> Effect<Action> {
     hasPendingFetch ? .send(.fetchAppUpdateStatus) : .none
   }
 }

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// Launching은 App 구동을 위한 Request 를 포함한 AppUpdate 상태를 관리합니다.
 struct Launching: Reducer {
   // MARK: - Enums
+  @ObservableState
   struct State: Equatable {
     struct BlockingAlert: Equatable {
       var title: String
@@ -29,24 +30,37 @@ struct Launching: Reducer {
     /// ContentView Display
     var displayContentView = false
     
-    var appUpdateFetchErrorAlert: AlertState<Action>?
+    @Presents var appUpdateFetchErrorAlert: AlertState<Action.AppUpdateFetchErrorAlert>?
     
-    var optionalUpdateAlert: AlertState<Action>?
+    @Presents var optionalUpdateAlert: AlertState<Action.OptionalUpdateAlert>?
     
-    var noticeAlert: AlertState<Action>?
+    @Presents var noticeAlert: AlertState<Action.NoticeAlert>?
 
     var blockingAlert: BlockingAlert?
   }
   
+  @CasePathable
   enum Action: Equatable {
+    @CasePathable
+    enum AppUpdateFetchErrorAlert: Equatable {}
+
+    @CasePathable
+    enum OptionalUpdateAlert: Equatable {
+      case doneTapped(appStoreURL: URL?)
+    }
+
+    @CasePathable
+    enum NoticeAlert: Equatable {}
+
+    case appUpdateFetchErrorAlert(PresentationAction<AppUpdateFetchErrorAlert>)
+
+    case optionalUpdateAlert(PresentationAction<OptionalUpdateAlert>)
+
+    case noticeAlert(PresentationAction<NoticeAlert>)
     
     /// AppUpdateStatus 를 Firebase.RemoteConfig 를 통해 가져옵니다.
     case fetchAppUpdateStatus
     
-    /// Action.fetchAppUpdateStatus 실패 후 Error 얼럿 Dismissed 시 호출되며
-    /// Action.fetchAppUpdateStatus 가 다시 호출 됩니다.
-    case appUpdateFetchErrorAlertDismissed
-
     /// Action.fetchAppUpdateStatus 취소 시 호출되며 진행 상태를 정리합니다.
     case fetchAppUpdateStatusCancelled
     
@@ -56,17 +70,8 @@ struct Launching: Reducer {
     /// 차단 화면의 버튼 선택 시 호출
     case blockingAlertButtonTapped(linkURL: URL?)
     
-    /// 선택 업데이트 얼럿 Dismissed 시 호출
-    case optionalUpdateAlertDismissed
-    
-    /// 선택 업데이트 얼럿의 `업데이트`를 유저가 선택 시 호출
-    case optionalUpdateAlertDoneTapped(appStoreURL: URL?)
-    
     /// Action.fetchAppUpdateState 실패하면 Error Alert를 호출
     case showFetchErrorAlert(errorMessage: String)
-    
-    /// 공지 얼럿 Dismissed 시 호출
-    case noticeAlertDismissed
   }
   
   @Dependency(\.launchingService)
@@ -107,12 +112,10 @@ struct Launching: Reducer {
 
     case .blockingAlertButtonTapped(let linkURL):
       return openExternalURL(linkURL)
-      
-    case .optionalUpdateAlertDismissed:
+
+    case .optionalUpdateAlert(.presented(.doneTapped(let appStoreURL))):
       state.optionalUpdateAlert = nil
-      return .none
-      
-    case .optionalUpdateAlertDoneTapped(let appStoreURL):
+
       switch state.appUpdateStatus {
       case .valid, .forcedUpdateRequired, .notice, nil:
         return .none
@@ -120,6 +123,13 @@ struct Launching: Reducer {
       case .optionalUpdateRequired:
         return openExternalURL(appStoreURL)
       }
+
+    case .optionalUpdateAlert(.dismiss):
+      state.optionalUpdateAlert = nil
+      return .none
+
+    case .optionalUpdateAlert:
+      return .none
       
     case .setAppUpdateStatus(let appVersionStatus):
       state.isFetching = false
@@ -164,7 +174,7 @@ struct Launching: Reducer {
           ButtonState(role: .cancel) {
             TextState(launchingAlertDefaultText.optionalUpdate.cancel)
           }
-          ButtonState(action: .optionalUpdateAlertDoneTapped(appStoreURL: updateAlert.alertDoneLinkURL)) {
+          ButtonState(action: .doneTapped(appStoreURL: updateAlert.alertDoneLinkURL)) {
             TextState(launchingAlertDefaultText.optionalUpdate.done)
           }
         } message: {
@@ -217,11 +227,14 @@ struct Launching: Reducer {
       }
       return .none
       
-    case .appUpdateFetchErrorAlertDismissed:
+    case .appUpdateFetchErrorAlert(.dismiss):
       state.appUpdateFetchErrorAlert = nil
       return .send(.fetchAppUpdateStatus)
-      
-    case .noticeAlertDismissed:
+
+    case .appUpdateFetchErrorAlert:
+      return .none
+
+    case .noticeAlert(.dismiss):
       state.noticeAlert = nil
       
       guard let appUpdateStatus = state.appUpdateStatus else { return .none }
@@ -234,6 +247,9 @@ struct Launching: Reducer {
         guard !noticeAlert.isAppTerminated else { return .none }
         return openExternalURL(noticeAlert.doneURL)
       }
+
+    case .noticeAlert:
+      return .none
     }
   }
 

--- a/Sources/LaunchingView/Private/Launching.swift
+++ b/Sources/LaunchingView/Private/Launching.swift
@@ -46,6 +46,9 @@ struct Launching: Reducer {
     /// Action.fetchAppUpdateStatus 실패 후 Error 얼럿 Dismissed 시 호출되며
     /// Action.fetchAppUpdateStatus 가 다시 호출 됩니다.
     case appUpdateFetchErrorAlertDismissed
+
+    /// Action.fetchAppUpdateStatus 취소 시 호출되며 진행 상태를 정리합니다.
+    case fetchAppUpdateStatusCancelled
     
     /// Action.fetchAppUpdateStatus 를 통해 AppUpdateStatus 를 세팅합니다.
     case setAppUpdateStatus(AppUpdateStatus)
@@ -89,10 +92,18 @@ struct Launching: Reducer {
         do {
           let appStatus = try await launchingService.fetchAppUpdateStatus()
           await send(.setAppUpdateStatus(appStatus))
+        } catch is CancellationError {
+          await send(.fetchAppUpdateStatusCancelled)
         } catch {
           await send(.showFetchErrorAlert(errorMessage: error.localizedDescription))
         }
       }
+
+    case .fetchAppUpdateStatusCancelled:
+      state.isFetching = false
+      let hasPendingFetch = state.hasPendingFetch
+      state.hasPendingFetch = false
+      return fetchAgainIfNeeded(hasPendingFetch)
 
     case .blockingAlertButtonTapped(let linkURL):
       return openExternalURL(linkURL)

--- a/Sources/LaunchingView/Public/AsyncLaunchingView.swift
+++ b/Sources/LaunchingView/Public/AsyncLaunchingView.swift
@@ -8,12 +8,12 @@
 import ComposableArchitecture
 import SwiftUI
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct AsyncLaunchingView<Content: View>: View {
-  @StateObject
-  private var viewStore: ViewStore<Launching.State, Launching.Action>
+  @State
+  private var store: StoreOf<Launching>
   
   private let contentView: () -> Content
   
@@ -27,60 +27,45 @@ public struct AsyncLaunchingView<Content: View>: View {
   ///   - content: The callback that SwiftUI contentView
   public init(@ViewBuilder content: @escaping () -> Content) {
     self.contentView = content
-    self._viewStore = StateObject(
-      wrappedValue: ViewStore(
-        Store(initialState: Launching.State()) {
-          Launching()
-        },
-        observe: { $0 }
-      )
+    self._store = State(
+      wrappedValue: Store(initialState: Launching.State()) {
+        Launching()
+      }
     )
   }
   
   public var body: some View {
-    launchContent(viewStore: viewStore)
-      .onChange(of: scenePhase, perform: handleScenePhaseChange)
-      .alert(optionalUpdateAlertBinding, action: handleAlertAction)
-      .alert(appUpdateFetchErrorAlertBinding, action: handleAlertAction)
-      .alert(noticeAlertBinding, action: handleAlertAction)
-  }
+    WithPerceptionTracking {
+      @Perception.Bindable var store = store
 
-  private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.optionalUpdateAlert },
-      send: .optionalUpdateAlertDismissed
-    )
-  }
-
-  private var appUpdateFetchErrorAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.appUpdateFetchErrorAlert },
-      send: .appUpdateFetchErrorAlertDismissed
-    )
-  }
-
-  private var noticeAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.noticeAlert },
-      send: .noticeAlertDismissed
-    )
+      launchContent(store: store)
+        .onChange(of: scenePhase, perform: handleScenePhaseChange)
+        .alert($store.scope(state: \.optionalUpdateAlert, action: \.optionalUpdateAlert))
+        .alert(
+          $store.scope(
+            state: \.appUpdateFetchErrorAlert,
+            action: \.appUpdateFetchErrorAlert
+          )
+        )
+        .alert($store.scope(state: \.noticeAlert, action: \.noticeAlert))
+    }
   }
 
   @ViewBuilder
-  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> some View {
-    if let blockingAlert = viewStore.blockingAlert {
-      blockingLaunchView(blockingAlert, viewStore: viewStore)
+  private func launchContent(store: StoreOf<Launching>) -> some View {
+    if let blockingAlert = store.blockingAlert {
+      blockingLaunchView(blockingAlert, store: store)
     } else {
       contentView()
         .onAppear {
-          viewStore.send(.fetchAppUpdateStatus)
+          store.send(.fetchAppUpdateStatus)
         }
     }
   }
 
   private func blockingLaunchView(
     _ blockingAlert: Launching.State.BlockingAlert,
-    viewStore: ViewStore<Launching.State, Launching.Action>
+    store: StoreOf<Launching>
   ) -> BlockingLaunchView {
     BlockingLaunchView(
       title: blockingAlert.title,
@@ -88,18 +73,13 @@ public struct AsyncLaunchingView<Content: View>: View {
       buttonTitle: blockingAlert.buttonTitle,
       linkURL: blockingAlert.linkURL,
       onButtonTapped: { linkURL in
-        viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
+        store.send(.blockingAlertButtonTapped(linkURL: linkURL))
       }
     )
   }
 
   private func handleScenePhaseChange(_ scenePhase: ScenePhase) {
     guard scenePhase == .active else { return }
-    viewStore.send(.fetchAppUpdateStatus)
-  }
-
-  private func handleAlertAction(_ action: Launching.Action?) {
-    guard let action else { return }
-    viewStore.send(action)
+    store.send(.fetchAppUpdateStatus)
   }
 }

--- a/Sources/LaunchingView/Public/AsyncLaunchingView.swift
+++ b/Sources/LaunchingView/Public/AsyncLaunchingView.swift
@@ -27,12 +27,14 @@ public struct AsyncLaunchingView<Content: View>: View {
   ///   - content: The callback that SwiftUI contentView
   public init(@ViewBuilder content: @escaping () -> Content) {
     self.contentView = content
-    let store = Store(
-      initialState: Launching.State()
-    ) {
-      Launching()
-    }
-    self._viewStore = StateObject(wrappedValue: ViewStore(store, observe: { $0 }))
+    self._viewStore = StateObject(
+      wrappedValue: ViewStore(
+        Store(initialState: Launching.State()) {
+          Launching()
+        },
+        observe: { $0 }
+      )
+    )
   }
   
   public var body: some View {

--- a/Sources/LaunchingView/Public/AsyncLaunchingView.swift
+++ b/Sources/LaunchingView/Public/AsyncLaunchingView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct AsyncLaunchingView<Content: View>: View {
-  @ObservedObject
+  @StateObject
   private var viewStore: ViewStore<Launching.State, Launching.Action>
   
   private let contentView: () -> Content
@@ -32,26 +32,15 @@ public struct AsyncLaunchingView<Content: View>: View {
     ) {
       Launching()
     }
-    self._viewStore = ObservedObject(wrappedValue: ViewStore(store, observe: { $0 }))
+    self._viewStore = StateObject(wrappedValue: ViewStore(store, observe: { $0 }))
   }
   
   public var body: some View {
-    let content = launchContent(viewStore: viewStore)
-    let sceneContent = AnyView(
-      content.onChange(of: scenePhase, perform: handleScenePhaseChange)
-    )
-    let optionalUpdateAlert = AnyView(sceneContent.alert(
-      optionalUpdateAlertBinding,
-      action: handleAlertAction
-    ))
-    let fetchErrorAlert = AnyView(optionalUpdateAlert.alert(
-      appUpdateFetchErrorAlertBinding,
-      action: handleAlertAction
-    ))
-    return AnyView(fetchErrorAlert.alert(
-      noticeAlertBinding,
-      action: handleAlertAction
-    ))
+    launchContent(viewStore: viewStore)
+      .onChange(of: scenePhase, perform: handleScenePhaseChange)
+      .alert(optionalUpdateAlertBinding, action: handleAlertAction)
+      .alert(appUpdateFetchErrorAlertBinding, action: handleAlertAction)
+      .alert(noticeAlertBinding, action: handleAlertAction)
   }
 
   private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
@@ -75,17 +64,16 @@ public struct AsyncLaunchingView<Content: View>: View {
     )
   }
 
-  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> AnyView {
+  @ViewBuilder
+  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> some View {
     if let blockingAlert = viewStore.blockingAlert {
-      return AnyView(blockingLaunchView(blockingAlert, viewStore: viewStore))
-    }
-
-    return AnyView(
+      blockingLaunchView(blockingAlert, viewStore: viewStore)
+    } else {
       contentView()
         .onAppear {
           viewStore.send(.fetchAppUpdateStatus)
         }
-    )
+    }
   }
 
   private func blockingLaunchView(

--- a/Sources/LaunchingView/Public/AsyncLaunchingView.swift
+++ b/Sources/LaunchingView/Public/AsyncLaunchingView.swift
@@ -12,7 +12,8 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct AsyncLaunchingView<Content: View>: View {
-  private let store: StoreOf<Launching>
+  @ObservedObject
+  private var viewStore: ViewStore<Launching.State, Launching.Action>
   
   private let contentView: () -> Content
   
@@ -26,49 +27,89 @@ public struct AsyncLaunchingView<Content: View>: View {
   ///   - content: The callback that SwiftUI contentView
   public init(@ViewBuilder content: @escaping () -> Content) {
     self.contentView = content
-    self.store = Store(
-      initialState: Launching.State(),
-      reducer: Launching()
-    )
+    let store = Store(
+      initialState: Launching.State()
+    ) {
+      Launching()
+    }
+    self._viewStore = ObservedObject(wrappedValue: ViewStore(store, observe: { $0 }))
   }
   
   public var body: some View {
-    WithViewStore(self.store, observe: { $0 }) { viewStore in
-      Group {
-        if let blockingAlert = viewStore.blockingAlert {
-          BlockingLaunchView(
-            title: blockingAlert.title,
-            message: blockingAlert.message,
-            buttonTitle: blockingAlert.buttonTitle,
-            linkURL: blockingAlert.linkURL,
-            onButtonTapped: { linkURL in
-              viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
-            }
-          )
-        } else {
-          contentView()
-            .onAppear {
-              viewStore.send(.fetchAppUpdateStatus)
-            }
-        }
-      }
-      .onChange(of: scenePhase) { newValue in
-        if newValue == .active {
+    let content = launchContent(viewStore: viewStore)
+    let sceneContent = AnyView(
+      content.onChange(of: scenePhase, perform: handleScenePhaseChange)
+    )
+    let optionalUpdateAlert = AnyView(sceneContent.alert(
+      optionalUpdateAlertBinding,
+      action: handleAlertAction
+    ))
+    let fetchErrorAlert = AnyView(optionalUpdateAlert.alert(
+      appUpdateFetchErrorAlertBinding,
+      action: handleAlertAction
+    ))
+    return AnyView(fetchErrorAlert.alert(
+      noticeAlertBinding,
+      action: handleAlertAction
+    ))
+  }
+
+  private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.optionalUpdateAlert },
+      send: .optionalUpdateAlertDismissed
+    )
+  }
+
+  private var appUpdateFetchErrorAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.appUpdateFetchErrorAlert },
+      send: .appUpdateFetchErrorAlertDismissed
+    )
+  }
+
+  private var noticeAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.noticeAlert },
+      send: .noticeAlertDismissed
+    )
+  }
+
+  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> AnyView {
+    if let blockingAlert = viewStore.blockingAlert {
+      return AnyView(blockingLaunchView(blockingAlert, viewStore: viewStore))
+    }
+
+    return AnyView(
+      contentView()
+        .onAppear {
           viewStore.send(.fetchAppUpdateStatus)
         }
+    )
+  }
+
+  private func blockingLaunchView(
+    _ blockingAlert: Launching.State.BlockingAlert,
+    viewStore: ViewStore<Launching.State, Launching.Action>
+  ) -> BlockingLaunchView {
+    BlockingLaunchView(
+      title: blockingAlert.title,
+      message: blockingAlert.message,
+      buttonTitle: blockingAlert.buttonTitle,
+      linkURL: blockingAlert.linkURL,
+      onButtonTapped: { linkURL in
+        viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
       }
-    }
-    .alert(
-      self.store.scope(state: \.optionalUpdateAlert),
-      dismiss: .optionalUpdateAlertDismissed
     )
-    .alert(
-      self.store.scope(state: \.appUpdateFetchErrorAlert),
-      dismiss: .appUpdateFetchErrorAlertDismissed
-    )
-    .alert(
-      self.store.scope(state: \.noticeAlert),
-      dismiss: .noticeAlertDismissed
-    )
+  }
+
+  private func handleScenePhaseChange(_ scenePhase: ScenePhase) {
+    guard scenePhase == .active else { return }
+    viewStore.send(.fetchAppUpdateStatus)
+  }
+
+  private func handleAlertAction(_ action: Launching.Action?) {
+    guard let action else { return }
+    viewStore.send(action)
   }
 }

--- a/Sources/LaunchingView/Public/Bundle+.swift
+++ b/Sources/LaunchingView/Public/Bundle+.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension Bundle {

--- a/Sources/LaunchingView/Public/LaunchingAlertDefaultText.swift
+++ b/Sources/LaunchingView/Public/LaunchingAlertDefaultText.swift
@@ -8,12 +8,12 @@
 import Dependencies
 import Foundation
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct LaunchingAlertDefaultText: Sendable {
   
-  @available(iOS 15.0, macOS 12, *)
+  @available(iOS 16.0, macOS 13, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   public struct ForceUpdate: Sendable {
@@ -30,7 +30,7 @@ public struct LaunchingAlertDefaultText: Sendable {
     }
   }
   
-  @available(iOS 15.0, macOS 12, *)
+  @available(iOS 16.0, macOS 13, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   public struct OptionalUpdate: Sendable {
@@ -50,7 +50,7 @@ public struct LaunchingAlertDefaultText: Sendable {
     }
   }
   
-  @available(iOS 15.0, macOS 12, *)
+  @available(iOS 16.0, macOS 13, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   public struct Notice: Sendable {
@@ -83,7 +83,7 @@ public struct LaunchingAlertDefaultText: Sendable {
   }
 }
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension LaunchingAlertDefaultText: TestDependencyKey {
@@ -92,7 +92,7 @@ extension LaunchingAlertDefaultText: TestDependencyKey {
   }
 }
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension DependencyValues {

--- a/Sources/LaunchingView/Public/LaunchingService+.swift
+++ b/Sources/LaunchingView/Public/LaunchingService+.swift
@@ -9,7 +9,7 @@ import Foundation
 import Dependencies
 import LaunchingService
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 private enum LaunchingServiceKey: DependencyKey {
@@ -17,7 +17,7 @@ private enum LaunchingServiceKey: DependencyKey {
   public static let testValue: any LaunchingInteractable = UnimplementedLaunchingService()
 }
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 private final class UnimplementedLaunchingService: LaunchingInteractable {
@@ -28,7 +28,7 @@ private final class UnimplementedLaunchingService: LaunchingInteractable {
   }
 }
 
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension DependencyValues {

--- a/Sources/LaunchingView/Public/LaunchingView.swift
+++ b/Sources/LaunchingView/Public/LaunchingView.swift
@@ -57,7 +57,8 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct LaunchingView<Content: View, LaunchScreen: View>: View {
-  private let store: StoreOf<Launching>
+  @ObservedObject
+  private var viewStore: ViewStore<Launching.State, Launching.Action>
   
   private let contentView: () -> Content
   private let launchScreen: () -> LaunchScreen
@@ -83,51 +84,93 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
     self.contentView = content
     self.launchScreen = launchScreen
     self._isUserCustomFlagFinished = isFinished
-    self.store = Store(
-      initialState: Launching.State(),
-      reducer: Launching()
-    )
+    let store = Store(
+      initialState: Launching.State()
+    ) {
+      Launching()
+    }
+    self._viewStore = ObservedObject(wrappedValue: ViewStore(store, observe: { $0 }))
   }
   
   public var body: some View {
-    WithViewStore(self.store, observe: { $0 }) { viewStore in
-      Group {
-        if let blockingAlert = viewStore.blockingAlert {
-          BlockingLaunchView(
-            title: blockingAlert.title,
-            message: blockingAlert.message,
-            buttonTitle: blockingAlert.buttonTitle,
-            linkURL: blockingAlert.linkURL,
-            onButtonTapped: { linkURL in
-              viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
-            }
-          )
-        } else if viewStore.displayContentView && isUserCustomFlagFinished {
-          contentView()
-        } else {
-          launchScreen()
-            .onAppear {
-              viewStore.send(.fetchAppUpdateStatus)
-            }
-        }
-      }
-      .onChange(of: scenePhase) { newValue in
-        if newValue == .active {
+    let content = launchContent(viewStore: viewStore)
+    let sceneContent = AnyView(
+      content.onChange(of: scenePhase, perform: handleScenePhaseChange)
+    )
+    let optionalUpdateAlert = AnyView(sceneContent.alert(
+      optionalUpdateAlertBinding,
+      action: handleAlertAction
+    ))
+    let fetchErrorAlert = AnyView(optionalUpdateAlert.alert(
+      appUpdateFetchErrorAlertBinding,
+      action: handleAlertAction
+    ))
+    return AnyView(fetchErrorAlert.alert(
+      noticeAlertBinding,
+      action: handleAlertAction
+    ))
+  }
+
+  private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.optionalUpdateAlert },
+      send: .optionalUpdateAlertDismissed
+    )
+  }
+
+  private var appUpdateFetchErrorAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.appUpdateFetchErrorAlert },
+      send: .appUpdateFetchErrorAlertDismissed
+    )
+  }
+
+  private var noticeAlertBinding: Binding<AlertState<Launching.Action>?> {
+    viewStore.binding(
+      get: { $0.noticeAlert },
+      send: .noticeAlertDismissed
+    )
+  }
+
+  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> AnyView {
+    if let blockingAlert = viewStore.blockingAlert {
+      return AnyView(blockingLaunchView(blockingAlert, viewStore: viewStore))
+    }
+
+    if viewStore.displayContentView && isUserCustomFlagFinished {
+      return AnyView(contentView())
+    }
+
+    return AnyView(
+      launchScreen()
+        .onAppear {
           viewStore.send(.fetchAppUpdateStatus)
         }
+    )
+  }
+
+  private func blockingLaunchView(
+    _ blockingAlert: Launching.State.BlockingAlert,
+    viewStore: ViewStore<Launching.State, Launching.Action>
+  ) -> BlockingLaunchView {
+    BlockingLaunchView(
+      title: blockingAlert.title,
+      message: blockingAlert.message,
+      buttonTitle: blockingAlert.buttonTitle,
+      linkURL: blockingAlert.linkURL,
+      onButtonTapped: { linkURL in
+        viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
       }
-    }
-    .alert(
-      self.store.scope(state: \.optionalUpdateAlert),
-      dismiss: .optionalUpdateAlertDismissed
     )
-    .alert(
-      self.store.scope(state: \.appUpdateFetchErrorAlert),
-      dismiss: .appUpdateFetchErrorAlertDismissed
-    )
-    .alert(
-      self.store.scope(state: \.noticeAlert),
-      dismiss: .noticeAlertDismissed
-    )
+  }
+
+  private func handleScenePhaseChange(_ scenePhase: ScenePhase) {
+    guard scenePhase == .active else { return }
+    viewStore.send(.fetchAppUpdateStatus)
+  }
+
+  private func handleAlertAction(_ action: Launching.Action?) {
+    guard let action else { return }
+    viewStore.send(action)
   }
 }

--- a/Sources/LaunchingView/Public/LaunchingView.swift
+++ b/Sources/LaunchingView/Public/LaunchingView.swift
@@ -53,12 +53,12 @@ import SwiftUI
 ///         }
 ///       }
 ///     }
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct LaunchingView<Content: View, LaunchScreen: View>: View {
-  @StateObject
-  private var viewStore: ViewStore<Launching.State, Launching.Action>
+  @State
+  private var store: StoreOf<Launching>
   
   private let contentView: () -> Content
   private let launchScreen: () -> LaunchScreen
@@ -84,62 +84,47 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
     self.contentView = content
     self.launchScreen = launchScreen
     self._isUserCustomFlagFinished = isFinished
-    self._viewStore = StateObject(
-      wrappedValue: ViewStore(
-        Store(initialState: Launching.State()) {
-          Launching()
-        },
-        observe: { $0 }
-      )
+    self._store = State(
+      wrappedValue: Store(initialState: Launching.State()) {
+        Launching()
+      }
     )
   }
   
   public var body: some View {
-    launchContent(viewStore: viewStore)
-      .onChange(of: scenePhase, perform: handleScenePhaseChange)
-      .alert(optionalUpdateAlertBinding, action: handleAlertAction)
-      .alert(appUpdateFetchErrorAlertBinding, action: handleAlertAction)
-      .alert(noticeAlertBinding, action: handleAlertAction)
-  }
+    WithPerceptionTracking {
+      @Perception.Bindable var store = store
 
-  private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.optionalUpdateAlert },
-      send: .optionalUpdateAlertDismissed
-    )
-  }
-
-  private var appUpdateFetchErrorAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.appUpdateFetchErrorAlert },
-      send: .appUpdateFetchErrorAlertDismissed
-    )
-  }
-
-  private var noticeAlertBinding: Binding<AlertState<Launching.Action>?> {
-    viewStore.binding(
-      get: { $0.noticeAlert },
-      send: .noticeAlertDismissed
-    )
+      launchContent(store: store)
+        .onChange(of: scenePhase, perform: handleScenePhaseChange)
+        .alert($store.scope(state: \.optionalUpdateAlert, action: \.optionalUpdateAlert))
+        .alert(
+          $store.scope(
+            state: \.appUpdateFetchErrorAlert,
+            action: \.appUpdateFetchErrorAlert
+          )
+        )
+        .alert($store.scope(state: \.noticeAlert, action: \.noticeAlert))
+    }
   }
 
   @ViewBuilder
-  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> some View {
-    if let blockingAlert = viewStore.blockingAlert {
-      blockingLaunchView(blockingAlert, viewStore: viewStore)
-    } else if viewStore.displayContentView && isUserCustomFlagFinished {
+  private func launchContent(store: StoreOf<Launching>) -> some View {
+    if let blockingAlert = store.blockingAlert {
+      blockingLaunchView(blockingAlert, store: store)
+    } else if store.displayContentView && isUserCustomFlagFinished {
       contentView()
     } else {
       launchScreen()
         .onAppear {
-          viewStore.send(.fetchAppUpdateStatus)
+          store.send(.fetchAppUpdateStatus)
         }
     }
   }
 
   private func blockingLaunchView(
     _ blockingAlert: Launching.State.BlockingAlert,
-    viewStore: ViewStore<Launching.State, Launching.Action>
+    store: StoreOf<Launching>
   ) -> BlockingLaunchView {
     BlockingLaunchView(
       title: blockingAlert.title,
@@ -147,18 +132,13 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
       buttonTitle: blockingAlert.buttonTitle,
       linkURL: blockingAlert.linkURL,
       onButtonTapped: { linkURL in
-        viewStore.send(.blockingAlertButtonTapped(linkURL: linkURL))
+        store.send(.blockingAlertButtonTapped(linkURL: linkURL))
       }
     )
   }
 
   private func handleScenePhaseChange(_ scenePhase: ScenePhase) {
     guard scenePhase == .active else { return }
-    viewStore.send(.fetchAppUpdateStatus)
-  }
-
-  private func handleAlertAction(_ action: Launching.Action?) {
-    guard let action else { return }
-    viewStore.send(action)
+    store.send(.fetchAppUpdateStatus)
   }
 }

--- a/Sources/LaunchingView/Public/LaunchingView.swift
+++ b/Sources/LaunchingView/Public/LaunchingView.swift
@@ -84,12 +84,14 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
     self.contentView = content
     self.launchScreen = launchScreen
     self._isUserCustomFlagFinished = isFinished
-    let store = Store(
-      initialState: Launching.State()
-    ) {
-      Launching()
-    }
-    self._viewStore = StateObject(wrappedValue: ViewStore(store, observe: { $0 }))
+    self._viewStore = StateObject(
+      wrappedValue: ViewStore(
+        Store(initialState: Launching.State()) {
+          Launching()
+        },
+        observe: { $0 }
+      )
+    )
   }
   
   public var body: some View {

--- a/Sources/LaunchingView/Public/LaunchingView.swift
+++ b/Sources/LaunchingView/Public/LaunchingView.swift
@@ -57,7 +57,7 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct LaunchingView<Content: View, LaunchScreen: View>: View {
-  @ObservedObject
+  @StateObject
   private var viewStore: ViewStore<Launching.State, Launching.Action>
   
   private let contentView: () -> Content
@@ -89,26 +89,15 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
     ) {
       Launching()
     }
-    self._viewStore = ObservedObject(wrappedValue: ViewStore(store, observe: { $0 }))
+    self._viewStore = StateObject(wrappedValue: ViewStore(store, observe: { $0 }))
   }
   
   public var body: some View {
-    let content = launchContent(viewStore: viewStore)
-    let sceneContent = AnyView(
-      content.onChange(of: scenePhase, perform: handleScenePhaseChange)
-    )
-    let optionalUpdateAlert = AnyView(sceneContent.alert(
-      optionalUpdateAlertBinding,
-      action: handleAlertAction
-    ))
-    let fetchErrorAlert = AnyView(optionalUpdateAlert.alert(
-      appUpdateFetchErrorAlertBinding,
-      action: handleAlertAction
-    ))
-    return AnyView(fetchErrorAlert.alert(
-      noticeAlertBinding,
-      action: handleAlertAction
-    ))
+    launchContent(viewStore: viewStore)
+      .onChange(of: scenePhase, perform: handleScenePhaseChange)
+      .alert(optionalUpdateAlertBinding, action: handleAlertAction)
+      .alert(appUpdateFetchErrorAlertBinding, action: handleAlertAction)
+      .alert(noticeAlertBinding, action: handleAlertAction)
   }
 
   private var optionalUpdateAlertBinding: Binding<AlertState<Launching.Action>?> {
@@ -132,21 +121,18 @@ public struct LaunchingView<Content: View, LaunchScreen: View>: View {
     )
   }
 
-  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> AnyView {
+  @ViewBuilder
+  private func launchContent(viewStore: ViewStore<Launching.State, Launching.Action>) -> some View {
     if let blockingAlert = viewStore.blockingAlert {
-      return AnyView(blockingLaunchView(blockingAlert, viewStore: viewStore))
-    }
-
-    if viewStore.displayContentView && isUserCustomFlagFinished {
-      return AnyView(contentView())
-    }
-
-    return AnyView(
+      blockingLaunchView(blockingAlert, viewStore: viewStore)
+    } else if viewStore.displayContentView && isUserCustomFlagFinished {
+      contentView()
+    } else {
       launchScreen()
         .onAppear {
           viewStore.send(.fetchAppUpdateStatus)
         }
-    )
+    }
   }
 
   private func blockingLaunchView(

--- a/Sources/LaunchingView/Public/SharedURL.swift
+++ b/Sources/LaunchingView/Public/SharedURL.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// Open URL macOS and iOS
-@available(iOS 15.0, macOS 12, *)
+@available(iOS 16.0, macOS 13, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public struct SharedURL: Sendable {

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -89,9 +89,10 @@ struct LaunchingViewTests {
             alertDoneLinkURL: stateURL
           )
         )
-      ),
-      reducer: Launching()
-    )
+      )
+    ) {
+      Launching()
+    }
     store.dependencies.openURL = OpenURLEffect { url in
       await recorder.open(url)
       return true
@@ -114,9 +115,10 @@ struct LaunchingViewTests {
     )
     let recorder = ExternalActionRecorder()
     let store = TestStore(
-      initialState: Launching.State(displayContentView: true),
-      reducer: Launching()
-    )
+      initialState: Launching.State(displayContentView: true)
+    ) {
+      Launching()
+    }
     store.dependencies.launchingAlertDefaultText = LaunchingAlertDefaultText(
       forceUpdate: .init(done: "Update")
     )
@@ -154,9 +156,10 @@ struct LaunchingViewTests {
     )
     let recorder = ExternalActionRecorder()
     let store = TestStore(
-      initialState: Launching.State(displayContentView: true),
-      reducer: Launching()
-    )
+      initialState: Launching.State(displayContentView: true)
+    ) {
+      Launching()
+    }
     store.dependencies.launchingAlertDefaultText = LaunchingAlertDefaultText(
       notice: .init(done: "Open")
     )
@@ -192,9 +195,10 @@ struct LaunchingViewTests {
       )
     )
     let store = TestStore(
-      initialState: Launching.State(isFetching: true),
-      reducer: Launching()
-    )
+      initialState: Launching.State(isFetching: true)
+    ) {
+      Launching()
+    }
     store.dependencies.launchingAlertDefaultText = LaunchingAlertDefaultText(
       forceUpdate: .init(done: "Update")
     )

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -211,6 +211,24 @@ struct LaunchingViewTests {
   }
 
   @Test
+  func fetchCancellationClearsFetchingWithoutShowingAlert() async {
+    let store = TestStore(
+      initialState: Launching.State()
+    ) {
+      Launching()
+    }
+    store.dependencies.launchingService = CancellingLaunchingService()
+
+    await store.send(.fetchAppUpdateStatus) {
+      $0.isFetching = true
+    }
+
+    await store.receive(.fetchAppUpdateStatusCancelled) {
+      $0.isFetching = false
+    }
+  }
+
+  @Test
   func fetchWhileFetchingRefreshesAgainAfterCurrentStatusFinishes() async {
     let url = URL(string: "https://example.com/force")!
     let forceStatus = AppUpdateStatus.forcedUpdateRequired(
@@ -271,6 +289,12 @@ private final class StubLaunchingService: LaunchingInteractable {
 
   func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
     status
+  }
+}
+
+private final class CancellingLaunchingService: LaunchingInteractable {
+  func fetchAppUpdateStatus() async throws -> AppUpdateStatus {
+    throw CancellationError()
   }
 }
 

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -185,6 +185,32 @@ struct LaunchingViewTests {
   }
 
   @Test
+  func fetchErrorClearsOtherAlertStates() async {
+    let store = TestStore(
+      initialState: Launching.State(
+        optionalUpdateAlert: AlertState {
+          TextState("Optional update")
+        },
+        noticeAlert: AlertState {
+          TextState("Notice")
+        }
+      )
+    ) {
+      Launching()
+    }
+
+    await store.send(.showFetchErrorAlert(errorMessage: "Network failed")) {
+      $0.optionalUpdateAlert = nil
+      $0.noticeAlert = nil
+      $0.appUpdateFetchErrorAlert = AlertState {
+        TextState(Bundle.main.displayName)
+      } message: {
+        TextState("Network failed")
+      }
+    }
+  }
+
+  @Test
   func fetchWhileFetchingRefreshesAgainAfterCurrentStatusFinishes() async {
     let url = URL(string: "https://example.com/force")!
     let forceStatus = AppUpdateStatus.forcedUpdateRequired(

--- a/Tests/LaunchingViewTests/LaunchingViewTests.swift
+++ b/Tests/LaunchingViewTests/LaunchingViewTests.swift
@@ -88,7 +88,14 @@ struct LaunchingViewTests {
             message: "",
             alertDoneLinkURL: stateURL
           )
-        )
+        ),
+        optionalUpdateAlert: AlertState {
+          TextState("Optional update")
+        } actions: {
+          ButtonState(action: .doneTapped(appStoreURL: actionURL)) {
+            TextState("Update")
+          }
+        }
       )
     ) {
       Launching()
@@ -98,7 +105,11 @@ struct LaunchingViewTests {
       return true
     }
 
-    await store.send(.optionalUpdateAlertDoneTapped(appStoreURL: actionURL)).finish()
+    await store.send(
+      .optionalUpdateAlert(.presented(.doneTapped(appStoreURL: actionURL)))
+    ) {
+      $0.optionalUpdateAlert = nil
+    }.finish()
 
     #expect(await recorder.openedURLs() == [actionURL])
   }
@@ -211,6 +222,39 @@ struct LaunchingViewTests {
   }
 
   @Test
+  func fetchErrorDismissRequestsRefresh() async {
+    let store = TestStore(
+      initialState: Launching.State(
+        appUpdateFetchErrorAlert: AlertState {
+          TextState("LaunchingView")
+        } message: {
+          TextState("Network failed")
+        }
+      )
+    ) {
+      Launching()
+    }
+    store.dependencies.launchingService = StubLaunchingService(status: .valid)
+
+    await store.send(.appUpdateFetchErrorAlert(.dismiss)) {
+      $0.appUpdateFetchErrorAlert = nil
+    }
+
+    await store.receive(.fetchAppUpdateStatus) {
+      $0.isFetching = true
+    }
+
+    await store.receive(.setAppUpdateStatus(.valid)) {
+      $0.isFetching = false
+      $0.appUpdateStatus = .valid
+      $0.displayContentView = true
+      $0.blockingAlert = nil
+      $0.optionalUpdateAlert = nil
+      $0.noticeAlert = nil
+    }
+  }
+
+  @Test
   func fetchCancellationClearsFetchingWithoutShowingAlert() async {
     let store = TestStore(
       initialState: Launching.State()
@@ -226,6 +270,42 @@ struct LaunchingViewTests {
     await store.receive(.fetchAppUpdateStatusCancelled) {
       $0.isFetching = false
     }
+  }
+
+  @Test
+  func noticeDismissOpensDoneURL() async {
+    let url = URL(string: "https://example.com/notice")!
+    let status = AppUpdateStatus.notice(
+      NoticeAlert(
+        title: "Notice",
+        message: "Please read",
+        isAppTerminated: false,
+        doneURL: url
+      )
+    )
+    let recorder = ExternalActionRecorder()
+    let store = TestStore(
+      initialState: Launching.State(
+        appUpdateStatus: status,
+        noticeAlert: AlertState {
+          TextState("Notice")
+        } message: {
+          TextState("Please read")
+        }
+      )
+    ) {
+      Launching()
+    }
+    store.dependencies.openURL = OpenURLEffect { url in
+      await recorder.open(url)
+      return true
+    }
+
+    await store.send(.noticeAlert(.dismiss)) {
+      $0.noticeAlert = nil
+    }.finish()
+
+    #expect(await recorder.openedURLs() == [url])
   }
 
   @Test


### PR DESCRIPTION
## 변경 사항
- `LaunchingService` 의존성을 `0.9.2`로 업데이트했습니다.
- The Composable Architecture를 `1.25.5`로 업데이트했습니다.
- TCA 1.25 요구사항에 맞춰 `swift-tools-version`을 `6.1`, 최소 지원 플랫폼을 iOS 16/macOS 13으로 상향했습니다.
- `ReducerProtocol`/`EffectTask`를 `Reducer`/`Effect`로 마이그레이션하고, fetch side effect를 `Effect.run`으로 정리했습니다.
- `ViewStore` 기반 관찰을 제거하고 `@ObservableState`, `@Presents`, `Perception` 기반 Store 관찰로 전환했습니다.
- optional/fetch error/notice alert 상태를 Presentation action으로 분리해 dismiss 및 button action 흐름을 reducer에서 테스트 가능하게 유지했습니다.
- fetch 실패 alert를 띄우기 전에 optional/notice alert 상태를 정리해 alert binding이 동시에 활성화되지 않도록 했습니다.
- README 플랫폼 배지와 public availability annotation을 iOS 16/macOS 13 기준으로 갱신했습니다.

## 검토 메모
- 사용자가 최소 지원 버전 상향을 허용해 TCA를 `1.23.2..<1.24.0`에 묶지 않고 `from: "1.25.5"`로 올렸습니다.
- README/DocC의 `0.9.1` 표기는 `LaunchingView` 패키지 릴리스 버전입니다. 이번 PR은 `LaunchingService 0.9.2` 내부 의존성 반영과 TCA 업데이트이므로 사용자 설치 예시 버전은 유지했습니다.
- 기존 리뷰의 `ViewStore` 생명주기, `AnyView`, fetch cancellation, alert 충돌 지적은 코드와 테스트로 반영했습니다.
- TCA 최신 권장 패턴 관련 지적은 `@ObservableState`/`@Presents` 전환으로 후속 보강했습니다.

## 검증
- `swift build`
- `swift test` (12 tests)
- `./GeneratingDocumentationSite`
- `git diff --check`
